### PR TITLE
Added:Workflow to differentiate in Dev and Production mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,12 @@ function createWindow() {
     })
     Menu.setApplicationMenu(null)
     // and load the index.html of the app.
-    mainWindow.loadFile('cv-frontend/indexDev.html')
+    if(process.env.NODE_ENV==="production"){
+        mainWindow.loadFile('cv-frontend/index.html')
+    }
+    else{
+        mainWindow.loadFile('cv-frontend/indexDev.html')
+    }
     ipcMain.on("overwrite", (e, { dir, data }) => {
         console.log(dir)
         fs.writeFile(dir, data, function (err) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
+    "start:prod": "NODE_ENV=production electron .",
     "build": "cd cv-frontend && npm run build",
     "install:all": "npm install && cd cv-frontend && npm install",
     "package:linux": "electron-packager . --overwrite --platform=linux --arch=x64 --out=out"


### PR DESCRIPTION
#6 
Added support for differentiating dev and production mode using environment variables 
You can run dev mode using:
`npm run start:prod`
@shubhankarsharma00 please review it